### PR TITLE
Fix enum interference with double-quoted string

### DIFF
--- a/Swift.sublime-syntax
+++ b/Swift.sublime-syntax
@@ -28,11 +28,11 @@ contexts:
        1: punctuation.definition.preprocessor
        2: meta.preprocessor.c
 ###################################################### ENUMS
-    - match: "(?:[^\\?\\!\\)\\w]|^)\\.([a-zA-Z]\\w*)(?=\\()"
+    - match: "(?:[^\\?\\!\\)\\\"\\w]|^)\\.([a-zA-Z]\\w*)(?=\\()"
       captures:
        1: constant.language.enum
       push: enum
-    - match: "(?:[^\\?\\!\\)\\w]|^)\\.([a-zA-Z]\\w*)"
+    - match: "(?:[^\\?\\!\\)\\\"\\w]|^)\\.([a-zA-Z]\\w*)"
       captures:
        1: constant.language.enum
 ###################################################### CONSTANTS

--- a/syntax_test.swift
+++ b/syntax_test.swift
@@ -192,6 +192,11 @@ func foo(a, b: String) { foo }
 //    ^ string
 //      ^ -string
 
+".foo"
+// <- string
+//^ string
+//   ^ string
+
 "foo \(bar + (foo * bar))"
 // <- string
 //   ^ punctuation.section


### PR DESCRIPTION
This is just a narrow fix for #7 bug. Added a test case for ".foo" and all previous tests still pass (I'll note that as of Xcode 8.0 the test case `.Foo+.Bar` shows an error in Xcode, but I figured that was a different issue).

Without tracking types from declarations there's not really a way to differentiate between a class property (or even a normal property, if you don't follow convention with enum naming) and an enum case if the enum case includes its type (e.g. `MyClass.property` and `MyEnum.case`). 

I'm not sure if marking property accesses as different from normal variables is something this project would like to do (or method calls), but if so it might be best to just lump enum cases in with however that's handled.