### PR TITLE
Add didSet, willSet, get, and set to control keywords

### DIFF
--- a/Swift.sublime-syntax
+++ b/Swift.sublime-syntax
@@ -80,7 +80,7 @@ contexts:
 ###################################################### CONTROL
     - match: \b(if|where|else|for|in|is|as|while|switch|do|defer|repeat)\b
       scope: keyword.control
-    - match: \b(break|fallthrough|guard|try|catch|throws?|rethrows|return|case|continue|default)\b
+    - match: \b(break|fallthrough|guard|try|catch|throws?|rethrows|return|case|continue|default|didSet|willSet|get|set)\b
       scope: keyword.control
     - match: '#(available)\b'
       scope: keyword.control


### PR DESCRIPTION
[The Swift Programming Language - Properties](https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift_Programming_Language/Properties.html)

Let me know if they should go elsewhere in the syntax and I'll make the change.

Thanks!