### PR TITLE
Fix multiline highlighting

### DIFF
--- a/Swift.sublime-syntax
+++ b/Swift.sublime-syntax
@@ -173,7 +173,7 @@ contexts:
     - meta_scope: string.quoted.double string.quoted.multiline
     - match: \\\(
       scope: punctuation.section.embedded
-      set: embedded
+      set: embedded_multiline
     - match: \\[ntr0\\"']
       scope: constant.character.escape.c
     - match: \\u{[[:xdigit:]]{1,8}}
@@ -188,7 +188,7 @@ contexts:
     - meta_scope: string.quoted.double string.quoted.raw
     - match: \\\(
       scope: punctuation.section.embedded
-      set: embedded
+      set: embedded_raw_1
     - match: \\[ntr0\\"']
       scope: constant.character.escape.c
     - match: \\u{[[:xdigit:]]{1,8}}
@@ -203,7 +203,7 @@ contexts:
     - meta_scope: string.quoted.double string.quoted.raw
     - match: \\\(
       scope: punctuation.section.embedded
-      set: embedded
+      set: embedded_raw_2
     - match: \\[ntr0\\"']
       scope: constant.character.escape.c
     - match: \\u{[[:xdigit:]]{1,8}}
@@ -218,7 +218,7 @@ contexts:
     - meta_scope: string.quoted.double string.quoted.raw
     - match: \\\(
       scope: punctuation.section.embedded
-      set: embedded
+      set: embedded_raw_3
     - match: \\[ntr0\\"']
       scope: constant.character.escape.c
     - match: \\u{[[:xdigit:]]{1,8}}
@@ -233,7 +233,7 @@ contexts:
     - meta_scope: string.quoted.double
     - match: \\\(
       scope: punctuation.section.embedded
-      set: embedded
+      set: embedded_double
     - match: \\[ntr0\\"']
       scope: constant.character.escape.c
     - match: \\u{[[:xdigit:]]{1,8}}
@@ -244,13 +244,41 @@ contexts:
       scope: invalid.illegal
     - match: '"'
       pop: true
-  embedded:
+  embedded_double:
     - include: main
     - match: \(
       push: nested
     - match: \)
       scope: punctuation.section.embedded
       set: string_double
+  embedded_multiline:
+    - include: main
+    - match: \(
+      push: nested
+    - match: \)
+      scope: punctuation.section.embedded
+      set: string_multiline
+  embedded_raw_1:
+    - include: main
+    - match: \(
+      push: nested
+    - match: \)
+      scope: punctuation.section.embedded
+      set: string_raw_1
+  embedded_raw_2:
+    - include: main
+    - match: \(
+      push: nested
+    - match: \)
+      scope: punctuation.section.embedded
+      set: string_raw_2
+  embedded_raw_3:
+    - include: main
+    - match: \(
+      push: nested
+    - match: \)
+      scope: punctuation.section.embedded
+      set: string_raw_3
   nested:
     - include: main
     - match: \(

--- a/syntax_test.swift
+++ b/syntax_test.swift
@@ -66,7 +66,7 @@ where { /**/ }
 #if FOO
 // <- punctuation.definition.preprocessor
 #endif
-//  ^ meta.preprocessor.c
+//  ^ source.swift punctuation.definition.preprocessor meta.preprocessor.swift
 
 if a || b
 // <- keyword
@@ -218,9 +218,19 @@ func foo(abc: inout String) { foo }
 //                     ^ -punctuation.section
 
 """f"oo"""
-// <- string
 // <- string.quoted.multiline
 //   ^ string.quoted
+
+"""
+f"oo\("bar")
+// <- string
+// <- string.quoted.multiline
+//  ^ punctuation.section.embedded
+//     ^ string.quoted.double
+//         ^ punctuation.section.embedded
+"""
+.bar
+// <- constant.language.enum
 
 #"te"st"#
 // <- string


### PR DESCRIPTION
Thanks for making this! It really helps with working on my apps on the train where battery life is more important than Xcode's convenience.

I have a fix for multiline strings that I'd like to contribute.

I already tried to deduplicate the `embedded_*` blocks using `include` but that doesn't seem to work, so I think we have to keep the blocks duplicated.

![image](https://user-images.githubusercontent.com/3819725/199160440-a57f6854-1e7f-4216-afe2-3a4c7a34fa96.png)
